### PR TITLE
Migrate from pkg_resources to importlib.resources

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,14 @@
 # Changelog
 
+### 1.1.3 - In Progress
+
+- Fix UserWarning for pkg_resources by migrating to importlib.resources. Fixes
+  [#44](https://github.com/smarie/python-genbadge/issues/44). PR
+  [#45](https://github.com/smarie/python-genbadge/pull/45) by [vonsteer](https://github.com/vonsteer).
+- Fix help exit_code issue when using newer versions of Python. Fixes 
+  [#46](https://github.com/smarie/python-genbadge/issues/46). PR
+  [#45](https://github.com/smarie/python-genbadge/pull/45) by [vonsteer](https://github.com/vonsteer).
+
 ### 1.1.2 - Bugfix and new packaging
 
 - Fix branch coverage rate comparison when used with --branch without actual branches. Fixes

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,6 +48,7 @@ install_requires =
     requests
     # note: do not use double quotes in these, this triggers a weird bug in PyCharm in debug mode only
     pathlib2;python_version<'3.2'
+    importlib_resources;python_version<'3.9'
 tests_require =
     pytest
 ;     flake8

--- a/src/genbadge/main.py
+++ b/src/genbadge/main.py
@@ -35,8 +35,9 @@ SILENT_HELP = ("When this flag is active nothing will be written to stdout. Note
                "is used as the output file.")
 
 
-@click.group()
-def genbadge():
+@click.group(invoke_without_command=True)
+@click.pass_context
+def genbadge(ctx):
     """
     Commandline utility to generate badges.
     To get help on each command use:
@@ -44,7 +45,9 @@ def genbadge():
         genbadge <cmd> --help
 
     """
-    pass
+    if ctx.invoked_subcommand is None:
+        click.echo(ctx.get_help())
+        ctx.exit(0)
 
 
 @genbadge.command(name="tests",

--- a/src/genbadge/utils_badge.py
+++ b/src/genbadge/utils_badge.py
@@ -21,11 +21,11 @@ except ImportError:  # pragma: no cover
 try:
     # Python 3.9+
     from importlib.resources import files, as_file
-except ImportError:
+except ImportError:  # pragma: no cover
     try:
         # Python 3.7-3.8 (importlib_resources backport)
         from importlib_resources import files, as_file
-    except ImportError:
+    except ImportError:  # pragma: no cover
         files = None
         as_file = None
 


### PR DESCRIPTION
Fixes #44 
Fixes #46

###  Description
<!--- Describe your changes in detail -->
+ Migrate from pkg_resources to importlib.resources, maintaining compatibility for older versions of python.
+ Fixed an issue where the click exit code is different depending on the python version, forcing a exit code 0 with a help callback.


###  Context and Motivation
<!--- Describe your reasoning for this change in detail -->
To solve #44 and prevent warnings for users running this library in newer python versions.